### PR TITLE
Match upstream

### DIFF
--- a/META
+++ b/META
@@ -1,5 +1,5 @@
 name = "delimcc"
-version = "201703"
+version = "201803"
 description = "delimited continuations in byte-code and native OCaml"
 
 archive(byte) = "delimcc.cma"

--- a/opam
+++ b/opam
@@ -1,0 +1,15 @@
+opam-version: "1.2"
+maintainer: "xramtsov@gmail.com"
+authors: ["Oleg Kiselyov"]
+homepage: "http://okmij.org/ftp/continuations/implementations.html#caml-shift"
+bug-reports: "https://github.com/zinid/delimcc/issues"
+dev-repo: "https://github.com/zinid/delimcc.git"
+license: "MIT"
+build: [
+  [make "all"]
+  [make "opt"]
+]
+remove: [["ocamlfind" "remove" "delimcc"]]
+depends: ["ocamlfind"]
+install: [make "findlib-install"]
+available: [ ocaml-version >= "4.04.0" ]

--- a/stacks.c
+++ b/stacks.c
@@ -55,7 +55,7 @@
   native-code OCaml, see stacks-native.c. See the latter file for
   justification.
 
-  $Id: stacks.c,v 1.1 2017/03/23 10:53:25 oleg Exp oleg $
+  $Id: stacks.c,v 1.2 2018/02/26 05:31:12 oleg Exp oleg $
 
  *------------------------------------------------------------------------
  */


### PR DESCRIPTION
This PR updates the file in this repository to match the upstream version from Oleg.

I reviewed the change and believe that they improve efficiency and correctness.

If this PR is merged, there remain only a few files that differ at the repository root (see `meld delimcc/ caml-shift/`, for example):

- `META` has a different version (by the way, I updated the META from 201703 to 201803; it will match if you do a 2018.03 tag/release)
- `Makefile` is quite different: I have partially reviewed the change and it looked like there were good reasons for some of the differences, so I didn't touch this repository's Makefile. Ultimately we should discuss the changes with Oleg and try to converge to simplify maintenance.
- `README` is your readme, translated from Oleg's into markdown. Oleg did not change his README I think, so I did not update yours. (Again, we should think about converging to reduce differences.)
- I added an `opam` file to allow pinning from the directory sources. In the opam file, you ( @zinid ) are marked as the package maintainer (using your git-commit email).
