### PR TITLE
Add support for OCaml 4.11.1

### DIFF
--- a/META
+++ b/META
@@ -1,6 +1,6 @@
 name = "delimcc"
-version = "201803"
+version = "20180525"
 description = "delimited continuations in byte-code and native OCaml"
 
 archive(byte) = "delimcc.cma"
-archive(native) = "delimcc.cmxa"
+archive(native) = "delimccopt.cmxa"

--- a/bench_exc.ml
+++ b/bench_exc.ml
@@ -94,19 +94,19 @@ let bench testf =
 
 let () = 
   Printf.printf "test1_ex\n\n";
-  bench (fun () -> test1_ex (make_test_data 110000));;
+  bench (fun () -> test1_ex (make_test_data 100000));;
 
 let () = 
   Printf.printf "test1_abort\n\n";
-  bench (fun () -> test1_abort (make_test_data 110000));;
+  bench (fun () -> test1_abort (make_test_data 100000));;
 
 let () = 
   Printf.printf "test2_ex\n\n";
-  bench (fun () -> test2_ex (make_test_data 110000));;
+  bench (fun () -> test2_ex (make_test_data 100000));;
 
 let () = 
   Printf.printf "test2_abort\n\n";
-  bench (fun () -> test2_abort (make_test_data 110000));;
+  bench (fun () -> test2_abort (make_test_data 100000));;
 
 (* The median result of 5 runs:
 OCaml 3.12

--- a/delimcc.ml
+++ b/delimcc.ml
@@ -146,7 +146,7 @@
  with all needed modules.
 
 
- $Id: delimcc.ml,v 1.1 2017/07/11 14:20:11 oleg Exp oleg $
+ $Id: delimcc.ml,v 1.3 2018/03/08 09:08:30 oleg Exp oleg $
 
 *)
 
@@ -309,7 +309,7 @@ let[@inline never]
   let () = ptop := {pfr_mark = p.mark; pfr_ek = get_ek ()} :: (!ptop) in
   let res = body () in
   p.mbox := (fun () -> res);
-  raise DelimCCE
+  raise_notrace DelimCCE
 
 let push_prompt (p : 'a prompt) (body : unit -> 'a) : 'a =
   try
@@ -323,7 +323,7 @@ let push_prompt (p : 'a prompt) (body : unit -> 'a) : 'a =
     | _ -> dbg_fatal_error "push_prompt: empty pstack on DelimCCE")
   | e -> match !ptop with
     | h::t -> assert (h.pfr_mark == p.mark); ptop := t; 
-	dbg_note "propagating exc"; raise e
+	dbg_note "propagating exc"; raise_notrace e
     | _ -> dbg_fatal_error "push_prompt: empty pstack on other exc"
 
 (*
@@ -334,11 +334,11 @@ let push_prompt (p : 'a prompt) (body : unit -> 'a) : 'a =
 *)
 
 let push_prompt_simple (p : 'a prompt) (body : unit -> unit) : 'a =
-  try body (); raise DelimCCE
+  try body (); raise_notrace DelimCCE
   with
   | DelimCCE -> mbox_receive p
   | Out_of_memory -> dbg_fatal_error "take_subcont: out of memory"
-  | e -> dbg_note "propagating exc"; raise e
+  | e -> dbg_note "propagating exc"; raise_notrace e
 
 let take_subcont (p : 'b prompt) (f : ('a,'b) subcont -> unit -> 'b) : 'a =
   let p' = new_prompt () in
@@ -422,7 +422,7 @@ let push_subcont (sk : ('a,'b) subcont) (m : unit -> 'a) : 'b =
     push_subcont_aux sk m 			(* does not return *)
   with 
   | DelimCCE -> mbox_receive sk.subcont_pb
-  | e -> dbg_note "propagating exc1"; raise e
+  | e -> dbg_note "propagating exc1"; raise_notrace e
 
 
 (* Another optimization: push the _delimited_ continuation.
@@ -457,7 +457,7 @@ let push_delim_subcont (sk : ('a,'b) subcont) (m : unit -> 'a) : 'b =
     | _ -> dbg_fatal_error "push_delim_subcont: empty pstack on DelimCCE")
   | e -> match !ptop with
     | h::t -> assert (h.pfr_mark == sk.subcont_pb.mark); ptop := t; 
-	dbg_note "propagating exc2"; raise e
+	dbg_note "propagating exc2"; raise_notrace e
     | _ -> dbg_fatal_error "push_delim_subcont: empty pstack on other exc"
 
 

--- a/stacks-native.c
+++ b/stacks-native.c
@@ -1002,10 +1002,17 @@ value dbg_fatal_error(const value message)
   return Val_unit;		/* Doesn't return, actually */
 }
 
+#if defined(DEBUG) && DEBUG
 value dbg_note(const value message)
 {
   myassert(Is_block(message) && Tag_val(message) == String_tag);
   fprintf(stderr,"%s\n",String_val(message));
   return Val_unit;
 }
+#else
+value dbg_note(const value message)
+{
+  return Val_unit;
+}
+#endif
 

--- a/stacks.c
+++ b/stacks.c
@@ -55,7 +55,7 @@
   native-code OCaml, see stacks-native.c. See the latter file for
   justification.
 
-  $Id: stacks.c,v 1.2 2018/02/26 05:31:12 oleg Exp oleg $
+  $Id: stacks.c,v 1.3 2018/05/25 12:57:10 oleg Exp oleg $
 
  *------------------------------------------------------------------------
  */
@@ -372,7 +372,10 @@ value size_stack_fragment(const value ekfragment)
 value dbg_fatal_error(const value message)
 {
   myassert(Is_block(message) && Tag_val(message) == String_tag);
-  caml_fatal_error(String_val(message));
+  /* Used to be caml_fatal_error. See correspondence with 
+     Sebastien.Hinderer@inria.fr, May 25, 2018 */
+  fprintf (stderr, "%s\n", String_val(message));
+  exit(2);
   return Val_unit;		/* Doesn't return, actually */
 }
 

--- a/stacks.c
+++ b/stacks.c
@@ -379,10 +379,17 @@ value dbg_fatal_error(const value message)
   return Val_unit;		/* Doesn't return, actually */
 }
 
+#if defined(DEBUG) && DEBUG
 value dbg_note(const value message)
 {
   myassert(Is_block(message) && Tag_val(message) == String_tag);
   fprintf(stderr,"%s\n",String_val(message));
   return Val_unit;
 }
+#else
+value dbg_note(const value message)
+{
+  return Val_unit;
+}
+#endif
 


### PR DESCRIPTION
The archive distributed by http://okmij.org/ftp/continuations/caml-shift.tar.gz was updated recently to add support for OCaml 4.11.1.

I also fixed the verbosity of `dbg_note` with the DEBUG constant.

Regards,
Gautier